### PR TITLE
feat(DataLib): add option to allow non-matched subdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /target
 /.project
 /.settings
+**/.factorypath
 *.iml
 /.idea/
 *.mwb.beforefix

--- a/source/src/main/java/org/cerberus/core/service/csvfile/ICsvFileService.java
+++ b/source/src/main/java/org/cerberus/core/service/csvfile/ICsvFileService.java
@@ -36,7 +36,18 @@ public interface ICsvFileService {
      * @param separator
      * @param columnsToGet
      * @param columnsToHide
+	 * @param ignoreNoMatchColumns      if <code>true</code> then populate all
+	 *                                  non-matched column with {@link String} empty
+	 *                                  value (""). Otherwise, all non-matched
+	 *                                  columns will not be included in the answer.
+	 *                                  Use {@link #IGNORE_NON_MATCHED_COLUMNS} &
+	 *                                  {@link #DO_NOT_IGNORE_NON_MATCHED_COLUMNS} for
+	 *                                  better readability
+	 * @param defaultNoMatchColumnValue the default value to set to any non-matched
+	 *                                  column if necessary
      * @return
      */
-    AnswerList<HashMap<String, String>> parseCSVFile(String urlToCSVFile, String separator, HashMap<String, String> columnsToGet,List<String> columnsToHide, TestCaseExecution execution);
+    AnswerList<HashMap<String, String>> parseCSVFile(String urlToCSVFile, String separator, HashMap<String, String> columnsToGet,List<String> columnsToHide, boolean ignoreNoMatchColumns, String defaultNoMatchColumnValue, TestCaseExecution execution);
+    boolean IGNORE_NON_MATCHED_COLUMNS = true;
+	boolean DO_NOT_IGNORE_NON_MATCHED_COLUMNS = false;
 }

--- a/source/src/main/java/org/cerberus/core/service/csvfile/ICsvFileService.java
+++ b/source/src/main/java/org/cerberus/core/service/csvfile/ICsvFileService.java
@@ -39,15 +39,10 @@ public interface ICsvFileService {
 	 * @param ignoreNoMatchColumns      if <code>true</code> then populate all
 	 *                                  non-matched column with {@link String} empty
 	 *                                  value (""). Otherwise, all non-matched
-	 *                                  columns will not be included in the answer.
-	 *                                  Use {@link #IGNORE_NON_MATCHED_COLUMNS} &
-	 *                                  {@link #DO_NOT_IGNORE_NON_MATCHED_COLUMNS} for
-	 *                                  better readability
+	 *                                  columns will not be included in the answer
 	 * @param defaultNoMatchColumnValue the default value to set to any non-matched
 	 *                                  column if necessary
      * @return
      */
     AnswerList<HashMap<String, String>> parseCSVFile(String urlToCSVFile, String separator, HashMap<String, String> columnsToGet,List<String> columnsToHide, boolean ignoreNoMatchColumns, String defaultNoMatchColumnValue, TestCaseExecution execution);
-    boolean IGNORE_NON_MATCHED_COLUMNS = true;
-	boolean DO_NOT_IGNORE_NON_MATCHED_COLUMNS = false;
 }

--- a/source/src/main/java/org/cerberus/core/service/csvfile/impl/CsvFileService.java
+++ b/source/src/main/java/org/cerberus/core/service/csvfile/impl/CsvFileService.java
@@ -48,7 +48,7 @@ public class CsvFileService implements ICsvFileService {
     private static final Logger LOG = LogManager.getLogger(CsvFileService.class);
 
     @Override
-    public AnswerList<HashMap<String, String>> parseCSVFile(String urlToCSVFile, String separator, HashMap<String, String> columnsToGet, List<String> columnsToHide, TestCaseExecution execution) {
+    public AnswerList<HashMap<String, String>> parseCSVFile(String urlToCSVFile, String separator, HashMap<String, String> columnsToGet, List<String> columnsToHide, boolean ignoreNoMatchColumns, String defaultNoMatchColumnValue, TestCaseExecution execution) {
         LOG.debug("Columns to hide : " + columnsToHide);
         String str = "";
         AnswerList<HashMap<String, String>> result = new AnswerList<>();
@@ -79,6 +79,11 @@ public class CsvFileService implements ICsvFileService {
             boolean noDataMapped = true;
             while (null != (str = br.readLine())) {
                 HashMap<String, String> line = new HashMap<>();
+                // In case of no match columns ignore, then first populate list with all column and default value
+                if (ignoreNoMatchColumns) {
+                	LOG.debug("Unmatched columns parsing enabled: Prefill columns with default value");
+                	columnsToGet.keySet().forEach((column) -> line.put(column, defaultNoMatchColumnValue));
+                }
                 Integer columnPosition = 1;
                 /**
                  * For each line, split result by separator, and put it in

--- a/source/src/main/java/org/cerberus/core/service/datalib/impl/DataLibService.java
+++ b/source/src/main/java/org/cerberus/core/service/datalib/impl/DataLibService.java
@@ -728,7 +728,7 @@ public class DataLibService implements IDataLibService {
                 columnsToHide = getListOfSecrets(lib.getTestDataLibID());
 
                 // CSV Call is made here.
-                responseList = fileService.parseCSVFile(servicePathCsv, lib.getSeparator(), columnList, columnsToHide, ignoreNonMatchedSubdata ? ICsvFileService.IGNORE_NON_MATCHED_COLUMNS : ICsvFileService.DO_NOT_IGNORE_NON_MATCHED_COLUMNS, defaultSubdataValue, execution);
+                responseList = fileService.parseCSVFile(servicePathCsv, lib.getSeparator(), columnList, columnsToHide, ignoreNonMatchedSubdata, defaultSubdataValue, execution);
                 list = responseList.getDataList();
 
                 //if the query returns sucess then we can get the data
@@ -780,7 +780,7 @@ public class DataLibService implements IDataLibService {
                                 Integer sqlTimeout = parameterService.getParameterIntegerByKey("cerberus_propertyexternalsql_timeout", system, 60);
 
                                 //performs a query that returns several rows containing n columns
-                                responseList = sqlService.queryDatabaseNColumns(connectionName, lib.getScript(), rowLimit, sqlTimeout, system, columnList, columnsToHide, ignoreNonMatchedSubdata ? ISQLService.IGNORE_NON_MATCHED_COLUMNS : ISQLService.DO_NOT_IGNORE_NON_MATCHED_COLUMNS, defaultSubdataValue, execution);
+                                responseList = sqlService.queryDatabaseNColumns(connectionName, lib.getScript(), rowLimit, sqlTimeout, system, columnList, columnsToHide, ignoreNonMatchedSubdata, defaultSubdataValue, execution);
 
                                 //if the query returns sucess then, we can get the data
                                 if (responseList.getResultMessage().getCode() == MessageEventEnum.PROPERTY_SUCCESS_SQL.getCode()) {

--- a/source/src/main/java/org/cerberus/core/service/sql/ISQLService.java
+++ b/source/src/main/java/org/cerberus/core/service/sql/ISQLService.java
@@ -86,9 +86,20 @@ public interface ISQLService {
      * @param system
      * @param columnsToGet
      * @param columnsToHide
+	 * @param ignoreNoMatchColumns         if <code>true</code> then ignore error if
+	 *                                     at least one column to get does not match
+	 *                                     with the SQL query result. In that case,
+	 *                                     each no match column's value will be set
+	 *                                     to the {@link String} empty value ("").
+	 *                                     Use {@link #IGNORE_NON_MATCHED_COLUMNS} &
+	 *                                     {@link #DO_NOT_IGNORE_NON_MATCHED_COLUMNS}
+	 *                                     for better readability
+	 * @param defaultNonMatchedColumnValue the default value to set to any
+	 *                                     non-matched column if necessary
      * @param execution
      * @return
      */
-    AnswerList<HashMap<String, String>> queryDatabaseNColumns(String connectionName, String sql, int rowLimit, int defaultTimeOut, String system, HashMap<String, String> columnsToGet, List<String> columnsToHide, TestCaseExecution execution);
-
+    AnswerList<HashMap<String, String>> queryDatabaseNColumns(String connectionName, String sql, int rowLimit, int defaultTimeOut, String system, HashMap<String, String> columnsToGet, List<String> columnsToHide, boolean ignoreNoMatchColumns, String defaultNonMatchedColumnValue, TestCaseExecution execution);
+    boolean IGNORE_NON_MATCHED_COLUMNS = true;
+	boolean DO_NOT_IGNORE_NON_MATCHED_COLUMNS = false;
 }

--- a/source/src/main/java/org/cerberus/core/service/sql/ISQLService.java
+++ b/source/src/main/java/org/cerberus/core/service/sql/ISQLService.java
@@ -90,16 +90,11 @@ public interface ISQLService {
 	 *                                     at least one column to get does not match
 	 *                                     with the SQL query result. In that case,
 	 *                                     each no match column's value will be set
-	 *                                     to the {@link String} empty value ("").
-	 *                                     Use {@link #IGNORE_NON_MATCHED_COLUMNS} &
-	 *                                     {@link #DO_NOT_IGNORE_NON_MATCHED_COLUMNS}
-	 *                                     for better readability
+	 *                                     to the {@link String} empty value ("")
 	 * @param defaultNonMatchedColumnValue the default value to set to any
 	 *                                     non-matched column if necessary
      * @param execution
      * @return
      */
     AnswerList<HashMap<String, String>> queryDatabaseNColumns(String connectionName, String sql, int rowLimit, int defaultTimeOut, String system, HashMap<String, String> columnsToGet, List<String> columnsToHide, boolean ignoreNoMatchColumns, String defaultNonMatchedColumnValue, TestCaseExecution execution);
-    boolean IGNORE_NON_MATCHED_COLUMNS = true;
-	boolean DO_NOT_IGNORE_NON_MATCHED_COLUMNS = false;
 }

--- a/source/src/main/java/org/cerberus/core/service/sql/impl/SQLService.java
+++ b/source/src/main/java/org/cerberus/core/service/sql/impl/SQLService.java
@@ -405,7 +405,7 @@ public class SQLService implements ISQLService {
     }
 
     @Override
-    public AnswerList<HashMap<String, String>> queryDatabaseNColumns(String connectionName, String sql, int rowLimit, int defaultTimeOut, String system, HashMap<String, String> columnsToGet, List<String> columnsToHide, TestCaseExecution execution) {
+    public AnswerList<HashMap<String, String>> queryDatabaseNColumns(String connectionName, String sql, int rowLimit, int defaultTimeOut, String system, HashMap<String, String> columnsToGet, List<String> columnsToHide, boolean ignoreNoMatchColumns, String defaultNoMatchColumnValue, TestCaseExecution execution) {
         AnswerList<HashMap<String, String>> listResult = new AnswerList<>();
         List<HashMap<String, String>> list;
         int maxSecurityFetch = parameterService.getParameterIntegerByKey("cerberus_testdatalib_fetchmax", system, 100);
@@ -451,13 +451,13 @@ public class SQLService implements ISQLService {
                                 row.put(name, valueSQL); // We put the result of the subData.
                                 nbColMatch++;
                             } catch (SQLException exception) {
-                                if (nbFetch == 0) {
-                                    if ("".equals(error_desc)) {
-                                        error_desc = column;
-                                    } else {
-                                        error_desc = error_desc + ", " + column;
-                                    }
-                                }
+                            	if (ignoreNoMatchColumns) {
+                            		LOG.debug("Unmatched columns parsing enabled: Fill unmatched column '{}' with default value", () -> name, () -> exception);
+                            		row.put(name,  defaultNoMatchColumnValue);
+                            		nbColMatch++;
+                            	} else {
+                            		error_desc = error_desc.isEmpty() ? column : error_desc + ", " + column;
+                            	}
                             }
                         }
 

--- a/source/src/main/resources/database.sql
+++ b/source/src/main/resources/database.sql
@@ -6229,10 +6229,15 @@ INSERT INTO `invariant` (`idname`, `value`, `sort`, `description`, `veryshortdes
 -- 1754
 ALTER TABLE tag MODIFY COLUMN Description TEXT NULL;
 
--- 1255
+-- 1755
 INSERT INTO `invariant` (`idname`, `value`, `sort`, `description`)
   VALUES   ('CAMPAIGN_TCCRITERIA', 'TESTFOLDER', 50 , '');
 
--- 1256
+-- 1756
 INSERT INTO `invariant` (`idname`, `value`, `sort`, `description`)
     VALUES   ('CONTROL','verifyElementTextNotContains',4210, 'verifyElementTextNotContains');
+
+-- 1757
+INSERT INTO `parameter` (`system`, `param`, `value`, `description`)
+  VALUES ('', 'cerberus_testdatalib_subdataDefaultValue', '', 'Default value when a subdata does not match with the datalib resultset (when the "cerberus_testdatalib_ignoreNonMatchedSubdata property" is set to true).'),
+         ('', 'cerberus_testdatalib_ignoreNonMatchedSubdata', 'false', 'If set to true, then allow subdata expression not to match the datalib resultset. Any non-matched subdata will be set by the "cerberus_testdatalib_subdataDefaultValue" property value.');


### PR DESCRIPTION
Please accept this PR that resolves #2491.
To avoid any breaking changes, I added an option to enable/disable allowing non-matched datalib's subdata and disabled this option by default.

Kind regards
Aurélien