### PR TITLE
feat(DataLib): set datalib null value with default non-matched subdata's one

### DIFF
--- a/source/src/main/java/org/cerberus/core/engine/gwt/impl/PropertyService.java
+++ b/source/src/main/java/org/cerberus/core/engine/gwt/impl/PropertyService.java
@@ -21,6 +21,8 @@ package org.cerberus.core.engine.gwt.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jayway.jsonpath.InvalidPathException;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cerberus.core.crud.entity.AppService;
@@ -1693,7 +1695,14 @@ public class PropertyService implements IPropertyService {
                 // Value of testCaseExecutionData object takes the master subdata entry "".
                 String value = result.get(0).get("");
                 if (value == null) {
-                    testCaseExecutionData.setValue(VALUE_NULL);
+                	final boolean ignoreNonMatchedSubdata = parameterService.getParameterBooleanByKey("cerberus_testdatalib_ignoreNonMatchedSubdata", StringUtils.EMPTY, false);
+                	if (ignoreNonMatchedSubdata) {
+                		final String defaultSubdataValue = ignoreNonMatchedSubdata ? parameterService.getParameterStringByKey("cerberus_testdatalib_subdataDefaultValue", StringUtils.EMPTY, StringUtils.EMPTY) : StringUtils.EMPTY;
+                		LOG.debug("Unmatched columns parsing enabled: Null answer received from service call of datalib '{}' with default value", () -> testDataLib.getName());
+                		testCaseExecutionData.setValue(defaultSubdataValue);
+                	} else {
+                		testCaseExecutionData.setValue(VALUE_NULL);
+                	}
                 } else {
                     testCaseExecutionData.setValue(value);
                     // Converting HashMap to json.

--- a/source/src/main/java/org/cerberus/core/service/sql/impl/SQLService.java
+++ b/source/src/main/java/org/cerberus/core/service/sql/impl/SQLService.java
@@ -443,7 +443,12 @@ public class SQLService implements ISQLService {
                             try {
                                 String valueSQL = resultSet.getString(column);
                                 if (valueSQL == null) { // If data is null from the database, we convert it to the static string <NULL>. 
-                                    valueSQL = PropertyService.VALUE_NULL;
+                                	if (ignoreNoMatchColumns) {
+                                		LOG.debug("Unmatched columns parsing enabled: Fill null value for column '{}' with default value", () -> name);
+                                		valueSQL = defaultNoMatchColumnValue;
+                                	} else {
+                                		valueSQL = PropertyService.VALUE_NULL;
+                                	}
                                 }
                                 if (columnsToHide.contains(name)) {
                                     execution.appendSecret(valueSQL);


### PR DESCRIPTION
Hello,

In the continuity of PR #2502, please accept this PR to deal with the case where subdata has a null value from an SQL column.
Thus, the same default value (`cerberus_testdatalib_subdataDefaultValue`) will be used whatever the _error_ scenario during subdata parsing (non-matched column or null column value), and will simplify testcase writing.
 
Kind regards
Aurélien