### PR TITLE
fix(UserSystemDAO): issue with creating usersystem on mysql 8

### DIFF
--- a/source/src/main/java/org/cerberus/core/crud/dao/impl/UserSystemDAO.java
+++ b/source/src/main/java/org/cerberus/core/crud/dao/impl/UserSystemDAO.java
@@ -394,7 +394,7 @@ public class UserSystemDAO implements IUserSystemDAO {
         Answer ans = new Answer(new MessageEvent(MessageEventEnum.DATA_OPERATION_OK));
         MessageEvent msg = null;
 
-        String query = "INSERT INTO usersystem(Login, System) SELECT ? , value FROM invariant where idname='SYSTEM' and " + SqlUtil.generateInClause("value", Arrays.asList(systemList)) + ";";
+        String query = "INSERT INTO `usersystem` (`login`, `system`) SELECT ? , value FROM invariant where idname='SYSTEM' and " + SqlUtil.generateInClause("value", Arrays.asList(systemList)) + ";";
 
         // Debug message on SQL.
         LOG.debug("SQL : {}", query);
@@ -429,7 +429,7 @@ public class UserSystemDAO implements IUserSystemDAO {
         Answer ans = new Answer(new MessageEvent(MessageEventEnum.DATA_OPERATION_OK));
         MessageEvent msg = null;
 
-        String query = "INSERT INTO usersystem(Login, System) SELECT ? , value FROM invariant where idname='SYSTEM' and value not like 'US-%';";
+        String query = "INSERT INTO `usersystem` (`login`, `system`) SELECT ? , value FROM invariant where idname='SYSTEM' and value not like 'US-%';";
 
         // Debug message on SQL.
         LOG.debug("SQL : {}", query);


### PR DESCRIPTION
Hi,

Actually we face an issue with the UserSystemDAO:

`XXXX-XX-XX XX:XX:XX WARN  UserSystemDAO:447 - Unable to create userSystem: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'System) SELECT 'xxxxxx@xxxx.com' , value FROM invariant where idname='' at line 1`

Technical stack:

Applicative version: Cerberus4.18-SNAPSHOT-1767  
MySQL version database :  8.0.30
Driver MySQL : mysql-connector-java-5.1.47
Java version : 11.0.22 (now) 
Apache Tomcat : 8.5.41

